### PR TITLE
Implement correction source

### DIFF
--- a/ac-ispell.el
+++ b/ac-ispell.el
@@ -118,7 +118,8 @@
 (defun ac-ispell-ac-setup ()
   "Add `ac-source-ispell' to `ac-sources' and enable `auto-complete' mode"
   (interactive)
-  (add-to-list 'ac-sources 'ac-source-ispell-fuzzy)
+  (unless (eq ac-ispell-fuzzy-limit 0)
+    (add-to-list 'ac-sources 'ac-source-ispell-fuzzy))
   (add-to-list 'ac-sources 'ac-source-ispell)
   (unless auto-complete-mode
     (auto-complete-mode +1)))


### PR DESCRIPTION
Add new source `ac-source-ispell-correction`.
This source provides possible corrections if `ac-prefix` is not found in dictionary.

![ac-ispell1](https://cloud.githubusercontent.com/assets/3389327/3443982/59b9bc5c-0129-11e4-9dff-149a952d5fcc.png)
