### PR TITLE
Improve cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ I recommend to use `custom-set-variables` for setting this value.
 Number of fuzzy completion candidates. If this value is `0`,
 fuzzy completion is disabled.
 
+#### `ac-ispell-cache-size`(Default `20`)
+
+Cache size.
+
 
 ## Sample Configuration
 

--- a/ac-ispell.el
+++ b/ac-ispell.el
@@ -1,11 +1,11 @@
 ;;; ac-ispell.el --- ispell completion source for auto-complete
 
-;; Copyright (C) 2014 by Syohei YOSHIDA
+;; Copyright (C) 2015 by Syohei YOSHIDA
 
 ;; Author: Syohei YOSHIDA <syohex@gmail.com>
 ;; URL: https://github.com/syohex/emacs-ac-ispell
 ;; Version: 0.06
-;; Package-Requires: ((auto-complete "1.4"))
+;; Package-Requires: ((auto-complete "1.4") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@
 
 (require 'auto-complete)
 (require 'ispell)
+(require 'ring)
 
 (defgroup ac-ispell nil
   "Auto completion with ispell."
@@ -58,12 +59,17 @@
   :type 'integer
   :group 'ac-ispell)
 
+(defcustom ac-ispell-cache-size 20
+  "Size of candidates cache."
+  :type 'integer
+  :group 'ac-ispell)
+
 (defface ac-ispell-fuzzy-candidate-face
   '((t (:inherit ac-candidate-face :foreground "red")))
   "Face for fuzzy candidate."
   :group 'ac-ispell)
 
-(defvar ac-ispell--cache nil)
+(defvar ac-ispell--cache (make-ring ac-ispell-cache-size))
 
 (defun ac-ispell--case-function (input)
   (let ((case-fold-search nil))
@@ -74,14 +80,14 @@
 (defun ac-ispell--lookup-candidates (lookup-func input)
   (let ((candidates (funcall lookup-func (concat input "*")
                              ispell-complete-word-dict)))
-    (setq ac-ispell--cache (cons input candidates))
+    (ring-insert ac-ispell--cache (cons input candidates))
     candidates))
 
 (defun ac-ispell--lookup-cache (input)
-  (let* ((cached-input (car ac-ispell--cache))
-         (regexp (concat "\\`" cached-input)))
-    (when (string-match-p regexp input)
-      (cdr ac-ispell--cache))))
+  (cl-loop for (prefix . candidates) in (ring-elements ac-ispell--cache)
+           for regexp = (concat "\\`" prefix)
+           when (string-match-p regexp input)
+           return candidates))
 
 (defun ac-ispell--candidates ()
   (let ((input (downcase ac-prefix))


### PR DESCRIPTION
Since cache is only one pair of input and candidates, but now ac-ispell caches
several pairs.
